### PR TITLE
Alpine based Dockerfile for GeoLite2xtables

### DIFF
--- a/contrib/Dockerfile/.dockerignore
+++ b/contrib/Dockerfile/.dockerignore
@@ -1,0 +1,2 @@
+LICENSE
+README.md

--- a/contrib/Dockerfile/Dockerfile
+++ b/contrib/Dockerfile/Dockerfile
@@ -1,0 +1,32 @@
+FROM alpine:3.8
+
+ARG commit=4e4ab880fc0c884d39b966de7819eb81084752b5
+
+WORKDIR /opt
+
+RUN \
+  echo \
+    http://nl.alpinelinux.org/alpine/v3.8/main >> /etc/apk/repositories && \
+  echo \
+    http://nl.alpinelinux.org/alpine/v3.8/community >> /etc/apk/repositories && \
+  apk add --no-cache --update \
+    bash curl perl perl-doc perl-netaddr-ip perl-text-csv_xs unzip xtables-addons && \
+  curl -L \
+    -o /tmp/GeoLite2xtables.zip \
+    https://github.com/mschmitt/GeoLite2xtables/archive/${commit}.zip && \
+  unzip -o \
+    /tmp/GeoLite2xtables.zip && \
+  mv \
+    ./GeoLite2xtables-${commit} ./GeoLite2xtables && \
+  mkdir \
+    /xt_build && \
+  rm \
+    /tmp/GeoLite2xtables.zip
+
+COPY ./xt_build.sh /opt/GeoLite2xtables
+
+RUN chmod +x /opt/GeoLite2xtables/xt_build.sh
+
+VOLUME /xt_build
+
+ENTRYPOINT ["/opt/GeoLite2xtables/xt_build.sh"]

--- a/contrib/Dockerfile/LICENSE
+++ b/contrib/Dockerfile/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Sander Spies.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/contrib/Dockerfile/README.md
+++ b/contrib/Dockerfile/README.md
@@ -1,0 +1,23 @@
+# Docker xtables_geoip image
+
+Docker image based on `alpine:3.8` with xtables-addons installed to build GeoIP tables with [Martin Schmitt's GeoLite2xtables][1] to create legacy format GeoIP database.
+
+A volume `/xt_build` can be used to get the results.
+
+## Build from source and run
+```
+$ git https://github.com/mschmitt/GeoLite2xtables.git
+$ cd GeoLite2xtables/contrib/Dockerfile
+$ docker build --tag=xtables_geoip .
+$ docker run --rm -v [path to folder]:/xt_build xtables_geoip
+```
+
+## Pull from [Docker Hub][2] and run
+```
+$ docker run --rm -v [path to folder]:/xt_build sander1/xtables_geoip
+```
+
+On Ubuntu the default GeoIP data folder is `/usr/share/xt_geoip`.
+
+[1]: https://github.com/mschmitt/GeoLite2xtables
+[2]: https://hub.docker.com/r/sander1/xtables_geoip

--- a/contrib/Dockerfile/README.md
+++ b/contrib/Dockerfile/README.md
@@ -6,7 +6,7 @@ A volume `/xt_build` can be used to get the results.
 
 ## Build from source and run
 ```
-$ git https://github.com/mschmitt/GeoLite2xtables.git
+$ git clone https://github.com/mschmitt/GeoLite2xtables.git
 $ cd GeoLite2xtables/contrib/Dockerfile
 $ docker build --tag=xtables_geoip .
 $ docker run --rm -v [path to folder]:/xt_build xtables_geoip

--- a/contrib/Dockerfile/xt_build.sh
+++ b/contrib/Dockerfile/xt_build.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+/opt/GeoLite2xtables/00_download_geolite2
+/opt/GeoLite2xtables/10_download_countryinfo
+cat /tmp/GeoLite2-Country-Blocks-IPv{4,6}.csv | /opt/GeoLite2xtables/20_convert_geolite2 /tmp/CountryInfo.txt > /xt_build/GeoIP-legacy.csv
+/usr/libexec/xtables-addons/xt_geoip_build -D /xt_build /xt_build/GeoIP-legacy.csv
+
+rm /tmp/CountryInfo.txt /tmp/GeoLite2-Country-Blocks-IPv{4,6}.csv


### PR DESCRIPTION
A Docker image based on `alpine:3.8` with xtables-addons installed to build GeoIP tables with your script to create legacy format GeoIP database.